### PR TITLE
Add onChange handler

### DIFF
--- a/src/ig-template/features/settings/BooleanSetting.ts
+++ b/src/ig-template/features/settings/BooleanSetting.ts
@@ -17,6 +17,6 @@ export class BooleanSetting extends Setting {
     }
 
     public toggle(): void {
-        this.value = !this.value;
+        this.set(!this.value);
     }
 }

--- a/src/ig-template/features/settings/Setting.ts
+++ b/src/ig-template/features/settings/Setting.ts
@@ -15,7 +15,7 @@ export abstract class Setting {
 
     requirement: Requirement;
 
-    protected _onChange = new SimpleEventDispatcher<SettingsValue>();
+    protected _onChange = new SimpleEventDispatcher<SettingsValue[]>();
 
     protected constructor(id: SettingId, displayName: string, options: SettingOption[], defaultValue: SettingsValue, requirement: Requirement = new NoRequirement()) {
         this.id = id;
@@ -31,7 +31,7 @@ export abstract class Setting {
    /**
      * Emitted whenever the setting is changed.
      */
-    public get onChange(): ISimpleEvent<SettingsValue> {
+    public get onChange(): ISimpleEvent<SettingsValue[]> {
         return this._onChange.asEvent();
     }
 
@@ -40,8 +40,9 @@ export abstract class Setting {
             return;
         }
         if (this.validValue(value)) {
+            const prevValue = this.value;
             this.value = value;
-            this._onChange.dispatch(value);
+            this._onChange.dispatch([prevValue, value]);
         } else {
             console.warn(`${value} is not a valid value for setting ${this.id}. It could be that the option is not yet unlocked.`);
         }

--- a/src/ig-template/features/settings/Setting.ts
+++ b/src/ig-template/features/settings/Setting.ts
@@ -28,7 +28,7 @@ export abstract class Setting {
         this.requirement = requirement;
     }
 
-   /**
+    /**
      * Emitted whenever the setting is changed.
      */
     public get onChange(): ISimpleEvent<SettingsValue[]> {

--- a/src/ig-template/features/settings/Setting.ts
+++ b/src/ig-template/features/settings/Setting.ts
@@ -15,7 +15,7 @@ export abstract class Setting {
 
     requirement: Requirement;
 
-    protected _onChange = new SimpleEventDispatcher<SettingsValue[]>();
+    protected _onChange = new SimpleEventDispatcher<[SettingsValue, SettingsValue]>();
 
     protected constructor(id: SettingId, displayName: string, options: SettingOption[], defaultValue: SettingsValue, requirement: Requirement = new NoRequirement()) {
         this.id = id;
@@ -31,7 +31,7 @@ export abstract class Setting {
     /**
      * Emitted whenever the setting is changed.
      */
-    public get onChange(): ISimpleEvent<SettingsValue[]> {
+    public get onChange(): ISimpleEvent<[SettingsValue, SettingsValue]> {
         return this._onChange.asEvent();
     }
 

--- a/src/ig-template/features/settings/Setting.ts
+++ b/src/ig-template/features/settings/Setting.ts
@@ -3,6 +3,7 @@ import {Requirement} from "@/ig-template/tools/requirements/Requirement";
 import {NoRequirement} from "@/ig-template/tools/requirements/NoRequirement";
 import {SettingOption} from "@/ig-template/features/settings/SettingOption";
 import {SettingsValue} from "@/ig-template/features/settings/SettingsValueType";
+import { ISimpleEvent, SimpleEventDispatcher } from "strongly-typed-events";
 
 
 export abstract class Setting {
@@ -13,6 +14,8 @@ export abstract class Setting {
     value: SettingsValue;
 
     requirement: Requirement;
+
+    protected _onChange = new SimpleEventDispatcher<SettingsValue>();
 
     protected constructor(id: SettingId, displayName: string, options: SettingOption[], defaultValue: SettingsValue, requirement: Requirement = new NoRequirement()) {
         this.id = id;
@@ -25,12 +28,20 @@ export abstract class Setting {
         this.requirement = requirement;
     }
 
+   /**
+     * Emitted whenever the setting is changed.
+     */
+    public get onChange(): ISimpleEvent<SettingsValue> {
+        return this._onChange.asEvent();
+    }
+
     set(value: SettingsValue): void {
         if (!this.canAccess) {
             return;
         }
         if (this.validValue(value)) {
             this.value = value;
+            this._onChange.dispatch(value);
         } else {
             console.warn(`${value} is not a valid value for setting ${this.id}. It could be that the option is not yet unlocked.`);
         }

--- a/tests/unit/ig-template/features/settings/Settings.spec.ts
+++ b/tests/unit/ig-template/features/settings/Settings.spec.ts
@@ -18,7 +18,7 @@ describe('Settings', () => {
                 new SettingOption("Option 2", 2),
                 new SettingOption("Option 3", 3),
             ], 2)
-        )
+        );
     });
 
     test('adding same setting multiple times', () => {
@@ -60,6 +60,20 @@ describe('Settings', () => {
         expect(() => {
             settings.setSetting("undefined setting" as SettingId, 1);
         }).not.toThrow()
+    });
+
+    test('test change event', () => {
+        expect.assertions(3);
+
+        const setting = settings.getSetting(id);
+        setting?.onChange.subscribe(value => {
+            expect(value).toBe(2);
+        });
+
+        settings.setSetting(id, 2);
+
+        expect(setting).toBeDefined();
+        expect(setting?.value).toBe(2);
     });
 
     test('save empty', () => {

--- a/tests/unit/ig-template/features/settings/Settings.spec.ts
+++ b/tests/unit/ig-template/features/settings/Settings.spec.ts
@@ -63,17 +63,18 @@ describe('Settings', () => {
     });
 
     test('test change event', () => {
-        expect.assertions(3);
+        expect.assertions(4);
 
         const setting = settings.getSetting(id);
-        setting?.onChange.subscribe(value => {
-            expect(value).toBe(2);
+        setting?.onChange.subscribe(([prevValue, value]) => {
+            expect(prevValue).toBe(2);
+            expect(value).toBe(3);
         });
 
-        settings.setSetting(id, 2);
+        settings.setSetting(id, 3);
 
         expect(setting).toBeDefined();
-        expect(setting?.value).toBe(2);
+        expect(setting?.value).toBe(3);
     });
 
     test('save empty', () => {


### PR DESCRIPTION
There might be some cases where you want to trigger some code when a setting is changed. A couple of examples:
* You're using a separate handling of dark theming from TailwindCSS that modifies the data-theme of the page.
* Changing a setting requires additional handling that's not fully handled by Vue.
* Possibly in the future when KeyBinding settings are implemented, you will want to update the Keybind whenever the player changes that setting.

Working off of the event handling for Achievements, I've added an `onChange` event dispatcher to the base `Setting` class. I couldn't match the Achievements implementation exactly since it's possible to update the setting value from the `Setting` instance directly, rather than it being fully controlled by the base `Feature`. It's also probably better to have individual subscriptions since you only want change handlers for specific settings anyways.

Also for this implementation I had to fix `BooleanSetting` to use the `set` method so it'll dispatch the `onChange` event as well.


