### PR TITLE
Implement SaveEncoder

### DIFF
--- a/src/ig-template/IgtGame.ts
+++ b/src/ig-template/IgtGame.ts
@@ -8,6 +8,8 @@ import {DeveloperPanelTab} from "@/ig-template/developer-panel/DeveloperPanelTab
 import {FunctionField} from "@/ig-template/developer-panel/fields/FunctionField";
 import {DisplayField} from "@/ig-template/developer-panel/fields/DisplayField";
 import {ChoiceField} from "@/ig-template/developer-panel/fields/ChoiceField";
+import { IgtSaveEncoder } from "./tools/saving/IgtSaveEncoder";
+import { DefaultSaveEncoder } from "./tools/saving/DefaultSaveEncoder";
 
 export abstract class IgtGame {
     protected _tickInterval: NodeJS.Timeout | null = null;
@@ -30,6 +32,7 @@ export abstract class IgtGame {
      */
     protected readonly SAVE_INTERVAL = 30;
     protected _nextSave = this.SAVE_INTERVAL;
+    protected saveEncoder: IgtSaveEncoder = new DefaultSaveEncoder();
 
     protected gameSpeed = 1;
     protected _lastUpdate: number = 0;
@@ -213,7 +216,7 @@ export abstract class IgtGame {
         for (const feature of this.featureList) {
             res[feature.saveKey] = feature.save()
         }
-        LocalStorage.store(this.SAVE_KEY, res)
+        LocalStorage.store(this.SAVE_KEY, res, this.saveEncoder)
     }
 
     /**
@@ -227,7 +230,7 @@ export abstract class IgtGame {
      * Recursively load all registered features
      */
     public load(): void {
-        const saveData = LocalStorage.get(this.SAVE_KEY)
+        const saveData = LocalStorage.get(this.SAVE_KEY, this.saveEncoder);
         if (saveData == null) {
             return;
         }

--- a/src/ig-template/tools/saving/DefaultSaveEncoder.ts
+++ b/src/ig-template/tools/saving/DefaultSaveEncoder.ts
@@ -1,0 +1,12 @@
+import { IgtSaveEncoder } from "./IgtSaveEncoder";
+
+export class DefaultSaveEncoder extends IgtSaveEncoder {
+
+    encode(data: string): string {
+        return data;
+    }
+    decode(data: string): string {
+        return data;
+    }
+
+}

--- a/src/ig-template/tools/saving/IgtSaveEncoder.ts
+++ b/src/ig-template/tools/saving/IgtSaveEncoder.ts
@@ -1,0 +1,15 @@
+export abstract class IgtSaveEncoder {
+    /**
+     * Encodes the stringified save data
+     * @param data The save data
+     * @returns An encoded save string to be stored in localStorage
+     */
+    abstract encode(data: string): string;
+
+    /**
+     * Decodes the save data into a JSON string
+     * @param data The save data
+     * @returns The save data in a JSON string format
+     */
+    abstract decode(data: string): string;
+}

--- a/src/ig-template/tools/saving/LocalStorage.ts
+++ b/src/ig-template/tools/saving/LocalStorage.ts
@@ -1,11 +1,15 @@
+import { IgtSaveEncoder } from "./IgtSaveEncoder";
+
 export class LocalStorage {
-    public static store(key: string, data: Record<string, unknown>): void {
-        localStorage.setItem(key, JSON.stringify(data));
+    public static store(key: string, data: Record<string, unknown>, saveEncoder: IgtSaveEncoder): void {
+        const saveString = saveEncoder.encode(JSON.stringify(data));
+        localStorage.setItem(key, saveString);
     }
 
     // TODO(@Isha) add error handling here
-    public static get(key: string): Record<string, unknown> {
-        return JSON.parse(localStorage.getItem(key) as string) as Record<string, unknown>;
+    public static get(key: string, saveEncoder: IgtSaveEncoder): Record<string, unknown> {
+        const saveString = saveEncoder.decode(localStorage.getItem(key) as string);
+        return JSON.parse(saveString) as Record<string, unknown>;
     }
 
     public static delete(key: string): void {

--- a/src/ig-template/tools/saving/index.ts
+++ b/src/ig-template/tools/saving/index.ts
@@ -2,3 +2,4 @@ export {LocalStorage} from "@/ig-template/tools/saving/LocalStorage";
 export {Saveable} from "@/ig-template/tools/saving/Saveable";
 export {SaveData} from "@/ig-template/tools/saving/SaveData";
 export {UpgradesFeatureSaveData} from "@/ig-template/tools/saving/UpgradesFeatureSaveData";
+export {IgtSaveEncoder} from "@/ig-template/tools/saving/IgtSaveEncoder"; 


### PR DESCRIPTION
Currently the base method of saving will always store the save data in the JSON string. There are two (fairly minor) problems with this:

1. It is fairly easy to open the console and see the save information. This can make cheating have a much lower barrier of entry.
2. Storing the save data as a JSON string takes many more characters than necessary. At the extremes this can cause the save to go beyond 5MB limit (though I doubt this is ever a problem).

This implementation adds an additional layer to the save framework using a new abstract `IgtSaveEncoder` class, which can be extended to encode and decode the save string. The `IgtGame` class (and thus user-extended `Game` classes) will have a new `saveEncoder` property which defaults to `DefaultSaveEncoder` (which doesn't do any encoding). This save encoder will be used when saving/loading from localStorage.

It might also be helpful to add a pre-built base64 save encoder to the library as that's one of the more commonly used encoding methods.