### PR TITLE
Implement DictStatistic

### DIFF
--- a/src/ig-template/features/statistics/DictStatistic.ts
+++ b/src/ig-template/features/statistics/DictStatistic.ts
@@ -1,0 +1,12 @@
+import {AbstractStatistic} from "@/ig-template/features/statistics/AbstractStatistic";
+import {StatisticId} from "@/ig-template/features/statistics/StatisticId";
+
+export class DictStatistic extends AbstractStatistic {
+    value: {[key: string]: number};
+
+    constructor(id: StatisticId, description: string, value: {[key: string]: number}) {
+        super(id, description);
+        this.value = value;
+    }
+
+}

--- a/src/ig-template/features/statistics/IgtStatistics.ts
+++ b/src/ig-template/features/statistics/IgtStatistics.ts
@@ -7,6 +7,7 @@ import {IgtFeature} from "@/ig-template/features/IgtFeature";
 import {AbstractStatistic} from "@/ig-template/features/statistics/AbstractStatistic";
 import {StatisticsSaveData} from "@/ig-template/features/statistics/StatisticsSaveData";
 import {ArrayStatistic} from "@/ig-template/features/statistics/ArrayStatistic";
+import {DictStatistic} from "@/ig-template/features/statistics/DictStatistic";
 
 export class IgtStatistics extends IgtFeature {
 
@@ -42,6 +43,19 @@ export class IgtStatistics extends IgtFeature {
         }
         const newValue = statistic.value[index] + amount;
         statistic.value.splice(index, 1, newValue);
+    }
+
+    incrementDictStatistic(id: StatisticId, key: string, amount = 1): void {
+        if (!this.hasStatistic(id)) {
+            console.warn(`Could not find statistic with id ${id}`)
+            return;
+        }
+        const statistic = this.list[id];
+        if (!(statistic instanceof DictStatistic)) {
+            console.warn(`Trying to treat ${id} as DictStatistic but it's not.`);
+            return;
+        }
+        statistic.value[key] += amount;
     }
 
     public getStatistic(id: StatisticId): AbstractStatistic | null {

--- a/src/ig-template/features/statistics/StatisticsValueType.ts
+++ b/src/ig-template/features/statistics/StatisticsValueType.ts
@@ -1,4 +1,4 @@
 /**
  * Add more types if statistics need to have different values
  */
-export type StatisticsValue = number | number[];
+export type StatisticsValue = number | number[] | {[key: string]: number};

--- a/src/ig-template/features/statistics/index.ts
+++ b/src/ig-template/features/statistics/index.ts
@@ -4,6 +4,7 @@ export {IgtStatistics} from "@/ig-template/features/statistics/IgtStatistics"
 export {NumberStatistic} from "@/ig-template/features/statistics/NumberStatistic"
 export {StatisticsSaveData} from "@/ig-template/features/statistics/StatisticsSaveData"
 export {StatisticsValue} from "@/ig-template/features/statistics/StatisticsValueType"
+export {DictStatistic} from "@/ig-template/features/statistics/DictStatistic"
 
 export {ArrayStatisticRequirement} from "@/ig-template/features/statistics/requirements/ArrayStatisticRequirement"
 export {NumberStatisticRequirement} from "@/ig-template/features/statistics/requirements/NumberStatisticRequirement"

--- a/tests/unit/ig-template/features/statistics/Statistics.spec.ts
+++ b/tests/unit/ig-template/features/statistics/Statistics.spec.ts
@@ -2,19 +2,25 @@ import {NumberStatistic} from "@/ig-template/features/statistics/NumberStatistic
 import {StatisticId} from "@/ig-template/features/statistics/StatisticId";
 import {IgtStatistics} from "@/ig-template/features/statistics/IgtStatistics";
 import {ArrayStatistic} from "@/ig-template/features/statistics/ArrayStatistic";
+import { DictStatistic } from "@/ig-template/features/statistics/DictStatistic";
 
 
 describe('Number Statistic', () => {
     const statistics = new IgtStatistics();
     const id = 'example' as StatisticId;
     const arrayId = 'array' as StatisticId;
+    const dictId = 'dict' as StatisticId;
     const stat = new NumberStatistic(id, 'get money', 0);
     const array = new ArrayStatistic(arrayId, 'array stat', [0, 0, 0]);
+    const dict = new DictStatistic(dictId, 'dict stat', {'stat1': 0, 'stat2': 0, 'stat3': 0});
     statistics.registerStatistic(stat);
     const arrayStat = statistics.registerStatistic(array);
+    const dictStat = statistics.registerStatistic(dict);
 
     beforeEach(() => {
         stat.value = 0;
+        array.value = [0, 0, 0];
+        dict.value = {'stat1': 0, 'stat2': 0, 'stat3': 0};
     })
 
     test('happy path', () => {
@@ -35,20 +41,32 @@ describe('Number Statistic', () => {
         // Assert
         statistics.incrementArrayStatistic(arrayStat.id, 1, 3)
         expect(arrayStat.value[1]).toBe(3);
+    });
 
+    test('dict statistic', () => {
+        // Assert
+        statistics.incrementDictStatistic(dictStat.id, 'stat1', 3);
+        expect(dictStat.value['stat1']).toBe(3);
     });
 
     test('save and load', () => {
         // Arrange
         statistics.incrementNumberStatistic(id, 20);
+        statistics.incrementArrayStatistic(arrayId, 1, 4);
+        statistics.incrementDictStatistic(dictId, 'stat2', 10);
         const save = statistics.save();
 
         statistics.list[id].value = 0;
+        statistics.list[arrayId].value = [0, 0, 0];
+        statistics.list[dictId].value = {};
 
         statistics.load(save)
         // Assert
         expect(statistics.getStatistic(id)?.value).toBe(20);
-
+        const arrayVal = (statistics.getStatistic(arrayId)?.value as number[])[1];
+        expect(arrayVal).toBe(4);
+        const dictVal = (statistics.getStatistic(dictId)?.value as any)['stat2'];
+        expect(dictVal).toBe(10);
     });
 
 });


### PR DESCRIPTION
Currently `StatisticsValue` is currently only defined as `number | number[]`, for `NumberStatistic` and `ArrayStatistic` respectively.

This is a bit limiting if you are attempting to store information for a collection of objects that don't map well into the `ArrayStatistic`. One such use case (and the reason why I created this PR), is storing a collection of objects in-game using a string enum as identifiers. I _could_ switch to a numbered ID system, but that's too much work :).

To accommodate for this, I've updated `StatisticsValue` to be defined as `number | number[] | {[key: string]: number}` and implemented a new `DictStatistic` class, which can be used to store statistics data defined by a collection of string IDs.