### PR TITLE
Add `onTick` event to `IgtGame`

### DIFF
--- a/src/ig-template/IgtGame.ts
+++ b/src/ig-template/IgtGame.ts
@@ -10,7 +10,7 @@ import { DisplayField } from '@/ig-template/developer-panel/fields/DisplayField'
 import { ChoiceField } from '@/ig-template/developer-panel/fields/ChoiceField';
 import { IgtSaveEncoder } from '@/ig-template/tools/saving';
 import { DefaultSaveEncoder } from '@/ig-template/tools/saving/DefaultSaveEncoder';
-import { EventDispatcher, IEvent } from 'strongly-typed-events';
+import { SimpleEventDispatcher, ISimpleEvent } from 'strongly-typed-events';
 
 export abstract class IgtGame {
   protected _tickInterval: NodeJS.Timeout | null = null;
@@ -28,7 +28,7 @@ export abstract class IgtGame {
    */
   protected abstract readonly TICK_DURATION: number;
 
-  protected _onTick = new EventDispatcher<IgtGame, number>();
+  protected _onTick = new SimpleEventDispatcher<number>();
 
   /**
    * How often the game should be saved
@@ -107,7 +107,7 @@ export abstract class IgtGame {
     for (const feature of this.featureList) {
       feature.update(delta);
     }
-    this._onTick.dispatch(this, delta);
+    this._onTick.dispatch(delta);
   }
 
   /**
@@ -154,14 +154,14 @@ export abstract class IgtGame {
     const delta = timeDifference * this.gameSpeed;
 
     this.update(now, delta);
-    this._onTick.dispatch(this, delta);
+    this._onTick.dispatch(delta);
   }
 
   /**
    * Emitted whenever the game ticks
    * @returns the onTick event
    */
-  public get onTick(): IEvent<IgtGame, number> {
+  public get onTick(): ISimpleEvent<number> {
     return this._onTick.asEvent();
   }
 

--- a/src/ig-template/IgtGame.ts
+++ b/src/ig-template/IgtGame.ts
@@ -103,7 +103,7 @@ export abstract class IgtGame {
    * Force updates all features
    * Sends the onTick event
    */
-  public forceUpdate(delta: number): void {
+  public fakeTick(delta: number): void {
     for (const feature of this.featureList) {
       feature.update(delta);
     }

--- a/tests/smoke/Game.spec.ts
+++ b/tests/smoke/Game.spec.ts
@@ -20,6 +20,10 @@ class DummyGame extends IgtGame {
 
   protected readonly SAVE_KEY: string = 'dummy';
   protected readonly TICK_DURATION: number = 0.05;
+
+  public get tickDuration(): number {
+    return this.TICK_DURATION;
+  }
 }
 
 /**
@@ -36,15 +40,27 @@ describe('Game launch smoke test', () => {
     statistics: new IgtStatistics(),
     achievements: new IgtAchievements(),
   });
+
+  const ticks: number = 100;
+
   test('smoke test', () => {
+    let tickCount = 0
+    game.onTick.subscribe((s: IgtGame, a: number) => {
+      tickCount++;
+      console.log('Tick', a)
+      expect(a).toEqual(game.tickDuration);
+    });
+
     expect(() => {
       game.initialize();
       game.load();
       game.start();
 
-      for (let i = 0; i < 100; i++) {
-        game.forceUpdate(0.5);
+      for (let i = 0; i < ticks; i++) {
+        game.forceUpdate(game.tickDuration);
       }
+
+      expect(tickCount).toBe(ticks);
     }).not.toThrow();
   });
 });

--- a/tests/smoke/Game.spec.ts
+++ b/tests/smoke/Game.spec.ts
@@ -62,7 +62,7 @@ describe('Game launch smoke test', () => {
       game.start();
 
       for (let i = 0; i < ticks; i++) {
-        game.forceUpdate(game.tickDuration);
+        game.fakeTick(game.tickDuration);
       }
 
       expect(tickCount).toBe(ticks);

--- a/tests/smoke/Game.spec.ts
+++ b/tests/smoke/Game.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test } from 'vitest';
 
 import { IgtGame } from '@/ig-template/IgtGame';
 import { IgtWallet } from '@/ig-template/features/wallet/IgtWallet';
@@ -26,28 +26,33 @@ class DummyGame extends IgtGame {
   }
 }
 
-/**
- * This smoke test starts the game and runs 100 game ticks.
- * It fails if any exceptions are thrown.
- */
 describe('Game launch smoke test', () => {
-  const game = new DummyGame({
-    wallet: new IgtWallet(['money']),
-    settings: new IgtSettings(),
-    codes: new IgtRedeemableCodes(),
-    keyItems: new IgtKeyItems(),
-    specialEvents: new IgtSpecialEvents(),
-    statistics: new IgtStatistics(),
-    achievements: new IgtAchievements(),
+  let game: DummyGame;
+
+  beforeEach(() => {
+    game = new DummyGame({
+      wallet: new IgtWallet(['money']),
+      settings: new IgtSettings(),
+      codes: new IgtRedeemableCodes(),
+      keyItems: new IgtKeyItems(),
+      specialEvents: new IgtSpecialEvents(),
+      statistics: new IgtStatistics(),
+      achievements: new IgtAchievements(),
+    });
   });
 
   const ticks: number = 100;
 
+  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  /**
+   * This smoke test starts the game and runs 100 game ticks.
+   * It fails if any exceptions are thrown.
+   */
   test('smoke test', () => {
-    let tickCount = 0
-    game.onTick.subscribe((_sender: IgtGame, event: number) => {
+    let tickCount = 0;
+    const unsub = game.onTick.sub((_sender: IgtGame, event: number) => {
       tickCount++;
-      console.log('Tick', event)
       expect(event).toEqual(game.tickDuration);
     });
 
@@ -62,5 +67,33 @@ describe('Game launch smoke test', () => {
 
       expect(tickCount).toBe(ticks);
     }).not.toThrow();
+
+    unsub();
+  });
+
+  test('starts and stops properly', async () => {
+    let tickCount = 0;
+    const unsub = game.onTick.sub((_sender, _event) => {
+      tickCount++;
+    });
+
+    game.initialize();
+    game.load();
+
+    const threeTicksMs = game.tickDuration * 3 * 1000;
+    await delay(threeTicksMs);
+    expect(tickCount).toBe(0);
+
+    game.start();
+    await delay(threeTicksMs);
+    expect(tickCount).toBeGreaterThan(0);
+
+    game.stop();
+    const tickCountAfterStop = tickCount;
+    expect(game.state).toBe('Stopped');
+    await delay(threeTicksMs);
+    expect(tickCount).toBe(tickCountAfterStop);
+
+    unsub();
   });
 });

--- a/tests/smoke/Game.spec.ts
+++ b/tests/smoke/Game.spec.ts
@@ -51,7 +51,7 @@ describe('Game launch smoke test', () => {
    */
   test('smoke test', () => {
     let tickCount = 0;
-    const unsub = game.onTick.sub((_sender: IgtGame, event: number) => {
+    const unsub = game.onTick.sub((event: number) => {
       tickCount++;
       expect(event).toEqual(game.tickDuration);
     });

--- a/tests/smoke/Game.spec.ts
+++ b/tests/smoke/Game.spec.ts
@@ -45,10 +45,10 @@ describe('Game launch smoke test', () => {
 
   test('smoke test', () => {
     let tickCount = 0
-    game.onTick.subscribe((s: IgtGame, a: number) => {
+    game.onTick.subscribe((_sender: IgtGame, event: number) => {
       tickCount++;
-      console.log('Tick', a)
-      expect(a).toEqual(game.tickDuration);
+      console.log('Tick', event)
+      expect(event).toEqual(game.tickDuration);
     });
 
     expect(() => {


### PR DESCRIPTION
Closes #25 

Added `onTick` event: 
- Moved creation of `setInterval` to it's own function `startTickInterval()`
- Changed function called by `setInterval()` from `update()` to `tick()` 
- `tick()` calls `update()` and dispatches the `onTick` event
- Pulled delta calculations out of `update()` and into `tick()`
- Added event subscription and tests to smoke test

> ## Tasks
> * [x]  Implement an `onTick(delta: number)` that is also a `SimpleEventDispatcher<number>` based on the `IgtWallet`
> * [x]  Improve the [Smoke test](https://github.com/123ishaTest/igt-library/blob/master/tests/smoke/Game.spec.ts) by listening to this event and make sure it is thrown the same amount of times as simulated in the test

